### PR TITLE
fix!: docker file input is now relative to the context input

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -72,7 +72,7 @@ runs:
       tags: ${{ steps.get-tags.outputs.tags }}
       secrets: ${{ inputs.build-secrets }}
       context: ${{ inputs.docker-context }}
-      file: ${{ inputs.docker-file }}
+      file: ${{ inputs.docker-context }}/${{ inputs.docker-file }}
       cache-from: type=gha,mode=max
       cache-to: type=gha,mode=max
       no-cache: ${{ contains(github.event.head_commit.message, 'no-cache') }}


### PR DESCRIPTION
This is a breaking change.
The docs say `docker-file` is relative to the `docker-context` input, and it should be.